### PR TITLE
Fix build error with duplicate include names

### DIFF
--- a/utils/src/list.c
+++ b/utils/src/list.c
@@ -10,7 +10,7 @@
  */
 
 
-#include "list.h"
+#include "utils/inc/list.h"
 
 void *nrf_wifi_utils_list_alloc(void)
 {

--- a/utils/src/queue.c
+++ b/utils/src/queue.c
@@ -9,8 +9,8 @@
  * for the Wi-Fi driver.
  */
 
-#include "list.h"
-#include "queue.h"
+#include "utils/inc/list.h"
+#include "utils/inc/queue.h"
 
 void *nrf_wifi_utils_q_alloc(void)
 {

--- a/utils/src/util.c
+++ b/utils/src/util.c
@@ -9,7 +9,7 @@
  * Wi-Fi driver.
  */
 
-#include <util.h>
+#include "utils/inc/util.h"
 #include "host_rpu_data_if.h"
 
 int nrf_wifi_utils_hex_str_to_val(unsigned char *hex_arr,


### PR DESCRIPTION
In the Zephyr Cmake build system the include paths have been adjusted to use top-level directory to avoid duplicating of "list.h" with "hostap" project and also extended the same for other two generic header names.